### PR TITLE
Adds sugar to appleberry bits

### DIFF
--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -6894,6 +6894,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/appleberry/Initialize()
 	. = ..()
 	reagents.add_reagent("milk", 8)
+	reagents.add_reagent("sugar", 5)
 
 /obj/item/weapon/reagent_containers/food/snacks/canned/ntbeans
 	name = "baked beans"


### PR DESCRIPTION
Appleberry bits are supposed to contain chunks of appleberries, ergo solid-food.

Lacking an "apple" reagent, sugar is the closest thing we can use. Adding 5 units of sugar due to beans having 4 protein.